### PR TITLE
refactor: switched to Fetch HTTP client

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,5 @@
 'use strict';
 const _ = require('lodash');
-const request = require('request-promise-native');
 
 const defaultConfig = {
   browserMob:{ host:'localhost',  port: 8080, protocol:'http' },
@@ -72,13 +71,20 @@ class BrowserMobClient {
     return this.callRest('proxy','GET');
   }
 
-  callRest(url ,method, data ){
-    return request({
-       method:method,
-       json:true,
-       body:data || {},
-       uri: `${ this.browserMob.uri }/${ url }`
-    });
+  async callRest(url ,method, data ){
+    const params = {
+      method:method
+    };
+    if (data) {
+      params.headers = { 'Content-Type': 'application/x-www-form-urlencoded' };
+      params.body = new URLSearchParams(data);
+    }
+    const response = await fetch(`${ this.browserMob.uri }/${ url }`, params);
+    const type = response.headers.get('content-type');
+    if (type && type === 'application/json')
+      return response.json();
+    else
+      return response.text();
   }
 
   _callProxy(ext, method, data, proxyPort){

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "browsermob-proxy-client",
     "har"
   ],
-  "version": "0.1.2",
+  "version": "0.2.0",
   "homepage": "https://github.com/BenRuns/bmp-client",
   "author": "Ben Patterson <ben@benpatterson.io>",
   "repository": {
@@ -22,16 +22,14 @@
   },
   "main": "./index.js",
   "dependencies": {
-    "request": "^2.81.0",
-    "lodash": "^4.17.4",
-    "request-promise-native": "^1.0.3"
+    "lodash": "^4.17.21"
   },
   "devDependencies": {
-    "chai": "4.3.6",
-    "chromedriver": "110.0.0",
-    "ip": "1.1.8",
-    "mocha": "10.2.0",
-    "selenium-webdriver": "4.5.0"
+    "chai": "^4.3.6",
+    "chromedriver": "124.0.3",
+    "ip": "2.0.1",
+    "mocha": "10.4.0",
+    "selenium-webdriver": "4.20.0"
   },
   "scripts": {
     "test": "mocha",

--- a/test/unit_test.js
+++ b/test/unit_test.js
@@ -90,6 +90,15 @@ describe('instance methods', function(){
         assert(response.port, 'should return something like { port:8081}' );
       });
     });
+
+    it("assign predefined port to the client", function(){
+      var proxy = BrowserMob.createClient();
+      return proxy.start({ port: 8180 })
+      .then( response => {
+        assert.equal(proxy.proxy.port, response.port );
+        assert.equal(response.port, 8180 );
+      });
+    });
   });
 
   describe('end', function(){


### PR DESCRIPTION
Current implementation with request client is using content-type json, which is not supported by BrowserMob Proxy version 2.1.4.

`curl -X POST -H "Content-Type: application/json" -d '{port:9090}' http://localhost:8080/proxy`

will ignore the data and return the next free port.

Current test cases did not cover the case of sending custom data.

Even though the request client supports sending formdata, the software is deprecated since 2020.
Node has native support for Fetch API (since v18), which from my perspective is a better alternative.